### PR TITLE
Fix login documentation, CORS origin, and test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
+  <a href="http://nestjs.com/" target="_blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
 </p>
 
 [circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function bootstrap() {
   }));
 
   app.enableCors({
-    origin: ["http:localhost:3001"],
+    origin: ["http://localhost:3001"],
     credentials: true,
   });
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -10,7 +10,7 @@
  *           schema:
  *             type: object
  *             properties:
- *               email:
+ *               usernameOrEmail:
  *                 type: string
  *               password:
  *                 type: string
@@ -22,7 +22,7 @@
  *             schema:
  *               type: object
  *               properties:
- *                 token:
+ *                 access_token:
  *                   type: string
- */
+*/
 router.post("/login", loginController);

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -16,6 +16,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')


### PR DESCRIPTION
## Summary
- fix README link target attribute
- correct CORS origin URL
- document usernameOrEmail and access_token for login endpoint
- close Nest app after tests

## Testing
- `npm test` *(fails: Cannot find module 'src/common/auth/public.decorator' and other missing modules)*
- `npm run test:e2e` *(fails: Cannot find module './medical-records/medical-records.module')*

------
https://chatgpt.com/codex/tasks/task_e_68b9a88bc4a08330978a26b66e1077dc